### PR TITLE
Fix movetag on castle

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -212,6 +212,7 @@ func castleMoves(pos *Position) []*Move {
 		!pos.inCheck {
 		m := &Move{s1: E1, s2: G1}
 		m.addTag(KingSideCastle)
+		addTags(m, pos)
 		moves = append(moves, m)
 	}
 	// white queen side
@@ -221,6 +222,7 @@ func castleMoves(pos *Position) []*Move {
 		!pos.inCheck {
 		m := &Move{s1: E1, s2: C1}
 		m.addTag(QueenSideCastle)
+		addTags(m, pos)
 		moves = append(moves, m)
 	}
 	// black king side
@@ -230,6 +232,7 @@ func castleMoves(pos *Position) []*Move {
 		!pos.inCheck {
 		m := &Move{s1: E8, s2: G8}
 		m.addTag(KingSideCastle)
+		addTags(m, pos)
 		moves = append(moves, m)
 	}
 	// black queen side
@@ -239,6 +242,7 @@ func castleMoves(pos *Position) []*Move {
 		!pos.inCheck {
 		m := &Move{s1: E8, s2: C8}
 		m.addTag(QueenSideCastle)
+		addTags(m, pos)
 		moves = append(moves, m)
 	}
 	return moves

--- a/game_test.go
+++ b/game_test.go
@@ -22,6 +22,24 @@ func TestCheckmate(t *testing.T) {
 	if g.Outcome() != WhiteWon {
 		t.Fatalf("expected outcome %s but got %s", WhiteWon, g.Outcome())
 	}
+
+	// Checkmate on castle
+	fenStr = "Q7/5Qp1/3k2N1/7p/8/4B3/PP3PPP/R3K2R w KQ - 0 31"
+	fen, err = FEN(fenStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	g = NewGame(fen)
+	if err := g.MoveStr("O-O-O"); err != nil {
+		t.Fatal(err)
+	}
+	if g.Method() != Checkmate {
+		t.Fatalf("expected method %s but got %s", Checkmate, g.Method())
+	}
+	if g.Outcome() != WhiteWon {
+		t.Fatalf("expected outcome %s but got %s", WhiteWon, g.Outcome())
+	}
+
 }
 
 func TestStalemate(t *testing.T) {


### PR DESCRIPTION
castleMoves() does not add Check tag on castle moves, unlike standardMoves(). The original code fails on the given test case on game_test.go